### PR TITLE
fix Token blacklist bug

### DIFF
--- a/backend/alembic/versions/2026_05_10_1516-afe1e469c3ca_add_token_version_to_users.py
+++ b/backend/alembic/versions/2026_05_10_1516-afe1e469c3ca_add_token_version_to_users.py
@@ -12,7 +12,6 @@ import sqlalchemy as sa
 
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision: str = "afe1e469c3ca"
 down_revision: str | None = "8b5c5cd24625"

--- a/backend/alembic/versions/2026_05_10_1516-afe1e469c3ca_add_token_version_to_users.py
+++ b/backend/alembic/versions/2026_05_10_1516-afe1e469c3ca_add_token_version_to_users.py
@@ -1,0 +1,31 @@
+"""add token_version to users
+
+Revision ID: afe1e469c3ca
+Revises: 8b5c5cd24625
+Create Date: 2026-05-10 15:16:02.130665
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "afe1e469c3ca"
+down_revision: str | None = "8b5c5cd24625"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("token_version", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "token_version")

--- a/backend/src/api/auth/login.py
+++ b/backend/src/api/auth/login.py
@@ -7,10 +7,11 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from core.dependencies import ClientIP, DBSession
 from core.rate_limiter import limiter
 from core.security import check_password, set_response_token_cookies
-from repository.user import UserUpdate, find_user_by_username, update_user
+from repository.user import UserUpdate, find_user_by_username, update_user, increment_token_version
 from schema.common import LoginRequest, UserLoginResponse
 from schema.jwt import TokenPayload
 from service.actions import ActionService
+
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ async def login(
 
     if result.new_hash:
         await update_user(session, user.user_id, UserUpdate(hash=result.new_hash))
+        await increment_token_version(session, user.user_id)
 
     if user.hash_date is not None:
         now = datetime.now()

--- a/backend/src/api/auth/login.py
+++ b/backend/src/api/auth/login.py
@@ -10,7 +10,6 @@ from core.security import check_password, set_response_token_cookies
 from repository.user import (
     UserUpdate,
     find_user_by_username,
-    increment_token_version,
     update_user,
 )
 from schema.common import LoginRequest, UserLoginResponse
@@ -53,7 +52,6 @@ async def login(
 
     if result.new_hash:
         await update_user(session, user.user_id, UserUpdate(hash=result.new_hash))
-        await increment_token_version(session, user.user_id)
 
     if user.hash_date is not None:
         now = datetime.now()

--- a/backend/src/api/auth/login.py
+++ b/backend/src/api/auth/login.py
@@ -7,11 +7,15 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from core.dependencies import ClientIP, DBSession
 from core.rate_limiter import limiter
 from core.security import check_password, set_response_token_cookies
-from repository.user import UserUpdate, find_user_by_username, update_user, increment_token_version
+from repository.user import (
+    UserUpdate,
+    find_user_by_username,
+    increment_token_version,
+    update_user,
+)
 from schema.common import LoginRequest, UserLoginResponse
 from schema.jwt import TokenPayload
 from service.actions import ActionService
-
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/api/auth/login.py
+++ b/backend/src/api/auth/login.py
@@ -56,7 +56,9 @@ async def login(
             logger.warning("Password expired for user: %s", data.username)
             raise HTTPException(status_code=401, detail="Password expired")
 
-    token_payload = TokenPayload(sub=str(user.user_id), username=data.username)
+    token_payload = TokenPayload(
+        sub=str(user.user_id), username=data.username, version=user.token_version
+    )
     set_response_token_cookies(response, token_payload)
 
     await action_service.log_login(user.user_id, ip)

--- a/backend/src/api/auth/logout.py
+++ b/backend/src/api/auth/logout.py
@@ -3,8 +3,10 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
+from core.dependencies import DBSession
 from core.rate_limiter import limiter
 from core.security import get_jwt_user
+from repository.user import increment_token_version
 from schema.common import Message
 from service.actions import ActionService
 
@@ -13,30 +15,28 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-# FIXME: token blacklist
 @router.post("/logout")
 @limiter.limit("1/minute")
 async def logout(
     request: Request,
     response: Response,
+    session: DBSession,
     action_service: Annotated[ActionService, Depends()],
 ) -> Message:
     """
     Выход пользователя.
 
-    Очищает куки JWT токенов доступа и обновления, логирует fau_logout.
+    Инвалидирует токены (инкрементит token_version),
+    очищает куки, логирует fau_logout.
     """
     try:
-        user = get_jwt_user(request)
+        user = await get_jwt_user(request, session)
+        await increment_token_version(session, user.user_id)
+        await action_service.log_logout(user.user_id, None)
     except HTTPException:
         logger.warning("Logout with invalid/missing token")
     except Exception as e:
         logger.warning("Failed to get user from token: %s", e)
-    else:
-        try:
-            await action_service.log_logout(user.user_id, None)
-        except Exception as e:
-            logger.warning("Failed to log logout action: %s", e)
 
     response.delete_cookie(key="access_token", path="/api")
     response.delete_cookie(key="refresh_token", path="/api")

--- a/backend/src/api/auth/logout.py
+++ b/backend/src/api/auth/logout.py
@@ -1,9 +1,10 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Depends, Query, Request, Response
 
 from core.dependencies import DBSession
+from core.exceptions import InvalidTokenError
 from core.rate_limiter import limiter
 from core.security import get_jwt_user
 from repository.user import increment_token_version
@@ -35,7 +36,7 @@ async def logout(
     user = None
     try:
         user = await get_jwt_user(request, session)
-    except HTTPException:
+    except InvalidTokenError:
         logger.warning("Logout with invalid/missing token")
 
     if user is not None and invalidate_all:

--- a/backend/src/api/auth/logout.py
+++ b/backend/src/api/auth/logout.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 
 from core.dependencies import DBSession
 from core.rate_limiter import limiter
@@ -22,6 +22,9 @@ async def logout(
     response: Response,
     session: DBSession,
     action_service: Annotated[ActionService, Depends()],
+    invalidate_all: Annotated[
+        bool, Query(True, description="Invalidate all active sessions")
+    ],
 ) -> Message:
     """
     Выход пользователя.
@@ -29,14 +32,20 @@ async def logout(
     Инвалидирует токены (инкрементит token_version),
     очищает куки, логирует fau_logout.
     """
+    user = None
     try:
         user = await get_jwt_user(request, session)
-        await increment_token_version(session, user.user_id)
-        await action_service.log_logout(user.user_id, None)
     except HTTPException:
         logger.warning("Logout with invalid/missing token")
-    except Exception as e:
-        logger.warning("Failed to get user from token: %s", e)
+
+    if user is not None and invalidate_all:
+        await increment_token_version(session, user.user_id)
+
+    if user is not None:
+        try:
+            await action_service.log_logout(user.user_id, None)
+        except Exception as e:
+            logger.warning("Failed to log logout action: %s", e)
 
     response.delete_cookie(key="access_token", path="/api")
     response.delete_cookie(key="refresh_token", path="/api")

--- a/backend/src/api/auth/logout.py
+++ b/backend/src/api/auth/logout.py
@@ -23,8 +23,8 @@ async def logout(
     session: DBSession,
     action_service: Annotated[ActionService, Depends()],
     invalidate_all: Annotated[
-        bool, Query(True, description="Invalidate all active sessions")
-    ],
+        bool, Query(description="Invalidate all active sessions")
+    ] = True,
 ) -> Message:
     """
     Выход пользователя.

--- a/backend/src/api/auth/refresh.py
+++ b/backend/src/api/auth/refresh.py
@@ -33,12 +33,12 @@ async def refresh(
 
     if payload.type != "refresh":
         logger.warning("Invalid refresh token type")
-        raise InvalidTokenError()
+        raise InvalidTokenError
 
     user = await get_user(session, int(payload.sub))
     if user is None or user.token_version != payload.version:
         logger.warning("Invalid refresh token")
-        raise InvalidTokenError()
+        raise InvalidTokenError
 
     token_payload = TokenPayload(
         sub=str(payload.sub), username=payload.username, version=user.token_version

--- a/backend/src/api/auth/refresh.py
+++ b/backend/src/api/auth/refresh.py
@@ -2,7 +2,9 @@ import logging
 
 from fastapi import APIRouter, HTTPException, Request, Response
 
+from core.dependencies import DBSession
 from core.security import set_response_token_cookies, verify_token
+from repository.user import get_user
 from schema.common import Message
 from schema.jwt import TokenPayload
 
@@ -11,9 +13,10 @@ router = APIRouter()
 
 
 @router.post("/refresh")
-def refresh(
+async def refresh(
     request: Request,
     response: Response,
+    session: DBSession,
 ) -> Message:
     """
     Обновление токена доступа.
@@ -31,7 +34,13 @@ def refresh(
         logger.warning("Invalid refresh token")
         raise HTTPException(status_code=403, detail="Invalid refresh token")
 
-    token_payload = TokenPayload(sub=str(payload.sub), username=payload.username)
+    user = await get_user(session, int(payload.sub))
+    if user is None:
+        raise HTTPException(status_code=403, detail="User not found")
+
+    token_payload = TokenPayload(
+        sub=str(payload.sub), username=payload.username, version=user.token_version
+    )
     set_response_token_cookies(response, token_payload)
 
     return Message(message="Access token refreshed")

--- a/backend/src/api/auth/refresh.py
+++ b/backend/src/api/auth/refresh.py
@@ -33,12 +33,12 @@ async def refresh(
 
     if payload.type != "refresh":
         logger.warning("Invalid refresh token type")
-        raise InvalidTokenError("Invalid token")
+        raise InvalidTokenError()
 
     user = await get_user(session, int(payload.sub))
     if user is None or user.token_version != payload.version:
         logger.warning("Invalid refresh token")
-        raise InvalidTokenError("Invalid token")
+        raise InvalidTokenError()
 
     token_payload = TokenPayload(
         sub=str(payload.sub), username=payload.username, version=user.token_version

--- a/backend/src/api/auth/refresh.py
+++ b/backend/src/api/auth/refresh.py
@@ -1,8 +1,9 @@
 import logging
 
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, Request, Response
 
 from core.dependencies import DBSession
+from core.exceptions import InvalidTokenError
 from core.security import set_response_token_cookies, verify_token
 from repository.user import get_user
 from schema.common import Message
@@ -26,17 +27,18 @@ async def refresh(
     refresh_token = request.cookies.get("refresh_token")
     if not refresh_token:
         logger.warning("Refresh token missing")
-        raise HTTPException(status_code=403, detail="Refresh token missing")
+        raise InvalidTokenError("Refresh token missing")
 
     payload = verify_token(refresh_token)
 
     if payload.type != "refresh":
-        logger.warning("Invalid refresh token")
-        raise HTTPException(status_code=403, detail="Invalid refresh token")
+        logger.warning("Invalid refresh token type")
+        raise InvalidTokenError("Invalid token")
 
     user = await get_user(session, int(payload.sub))
-    if user is None:
-        raise HTTPException(status_code=403, detail="User not found")
+    if user is None or user.token_version != payload.version:
+        logger.warning("Invalid refresh token")
+        raise InvalidTokenError("Invalid token")
 
     token_payload = TokenPayload(
         sub=str(payload.sub), username=payload.username, version=user.token_version

--- a/backend/src/core/exceptions.py
+++ b/backend/src/core/exceptions.py
@@ -148,3 +148,8 @@ class RecordLimitExceededError(APIException):
             ),
             400,
         )
+
+
+class InvalidTokenError(APIException):
+    def __init__(self, detail: str = "Invalid token") -> None:
+        super().__init__("INVALID_TOKEN", detail, 401)

--- a/backend/src/core/model.py
+++ b/backend/src/core/model.py
@@ -47,6 +47,7 @@ class User(Base):
     rating: Mapped[int | None] = mapped_column(Integer)
     email: Mapped[str | None] = mapped_column(Text)
     region: Mapped[str | None] = mapped_column(Text)
+    token_version: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
 
 
 class Publication(Base):

--- a/backend/src/core/security.py
+++ b/backend/src/core/security.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import settings
-from core.database import get_session
+from core.dependencies import DBSession
 from core.exceptions import AdminOnlyError, InvalidTokenError
 from repository.user import get_user
 from schema.jwt import Token, TokenPayload
@@ -136,7 +136,7 @@ def verify_token(token: str) -> Token:
 
 async def get_jwt_user(
     request: Request,
-    session: Annotated[AsyncSession, Depends(get_session)],
+    session: DBSession,
 ) -> UserMinimal:
     token = request.cookies.get("access_token")
     if not token:
@@ -156,7 +156,7 @@ async def get_jwt_user(
     user = await get_user(session, user_id)
     if user is None or user.token_version != payload.version:
         logger.warning("Token version mismatch or user not found")
-        raise InvalidTokenError("Invalid token")
+        raise InvalidTokenError
 
     return UserMinimal(user_id=user_id, name=payload.username)
 

--- a/backend/src/core/security.py
+++ b/backend/src/core/security.py
@@ -14,7 +14,9 @@ from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import settings
+from core.database import get_session
 from core.exceptions import AdminOnlyError
+from repository.user import get_user
 from schema.jwt import Token, TokenPayload
 from schema.user import UserMinimal
 
@@ -86,8 +88,7 @@ def create_access_token(payload: TokenPayload) -> str:
     )
 
     data = Token(
-        sub=payload.sub,
-        username=payload.username,
+        **payload.model_dump(),
         type="access",
         exp=expires,
     )
@@ -103,8 +104,7 @@ def create_refresh_token(payload: TokenPayload) -> str:
     )
 
     data = Token(
-        sub=payload.sub,
-        username=payload.username,
+        **payload.model_dump(),
         type="refresh",
         exp=expires,
     )
@@ -114,7 +114,6 @@ def create_refresh_token(payload: TokenPayload) -> str:
     )
 
 
-# FIXME: token blacklist
 def verify_token(token: str) -> Token:
     try:
         return Token.model_validate(
@@ -141,8 +140,9 @@ def verify_token(token: str) -> Token:
         ) from e
 
 
-def get_jwt_user(
+async def get_jwt_user(
     request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
 ) -> UserMinimal:
     token = request.cookies.get("access_token")
     if not token:
@@ -159,11 +159,20 @@ def get_jwt_user(
         )
 
     try:
-        return UserMinimal(user_id=int(payload.sub), name=payload.username)
+        user_id = int(payload.sub)
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
         ) from e
+
+    user = await get_user(session, user_id)
+    if user is None or user.token_version != payload.version:
+        logger.warning("Token version mismatch or user not found")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Token invalidated"
+        )
+
+    return UserMinimal(user_id=user_id, name=payload.username)
 
 
 def check_admin(
@@ -184,6 +193,6 @@ def validate_user_id(user_id: int, token_id: int) -> int:
 
 def validate_user_id_path(
     user_id: int,
-    token: Annotated[UserMinimal, Depends(get_jwt_user)],
+    token: Annotated[UserMinimal, Depends(get_jwt_user)],  # type: ignore[misc]
 ) -> int:
     return validate_user_id(user_id, token.user_id)

--- a/backend/src/core/security.py
+++ b/backend/src/core/security.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import settings
 from core.database import get_session
-from core.exceptions import AdminOnlyError
+from core.exceptions import AdminOnlyError, InvalidTokenError
 from repository.user import get_user
 from schema.jwt import Token, TokenPayload
 from schema.user import UserMinimal
@@ -125,19 +125,13 @@ def verify_token(token: str) -> Token:
         )
     except jwt.ExpiredSignatureError as e:
         logger.warning("Token expired")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Token expired"
-        ) from e
+        raise InvalidTokenError("Token expired") from e
     except DecodeError as e:
         logger.warning("Invalid token: %s", e)
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
-        ) from e
+        raise InvalidTokenError from e
     except ValidationError as e:
         logger.warning("Invalid token: %s", e)
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
-        ) from e
+        raise InvalidTokenError from e
 
 
 async def get_jwt_user(
@@ -147,30 +141,22 @@ async def get_jwt_user(
     token = request.cookies.get("access_token")
     if not token:
         logger.warning("Missing access token")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Missing access token"
-        )
+        raise InvalidTokenError("Missing access token")
 
     payload = verify_token(token)
     if payload.type != "access":
         logger.warning("Invalid token type")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
-        )
+        raise InvalidTokenError("Invalid token type")
 
     try:
         user_id = int(payload.sub)
     except ValueError as e:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token"
-        ) from e
+        raise InvalidTokenError from e
 
     user = await get_user(session, user_id)
     if user is None or user.token_version != payload.version:
         logger.warning("Token version mismatch or user not found")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Token invalidated"
-        )
+        raise InvalidTokenError("Invalid token")
 
     return UserMinimal(user_id=user_id, name=payload.username)
 
@@ -193,6 +179,6 @@ def validate_user_id(user_id: int, token_id: int) -> int:
 
 def validate_user_id_path(
     user_id: int,
-    token: Annotated[UserMinimal, Depends(get_jwt_user)],  # type: ignore[misc]
+    token: Annotated[UserMinimal, Depends(get_jwt_user)],
 ) -> int:
     return validate_user_id(user_id, token.user_id)

--- a/backend/src/repository/user.py
+++ b/backend/src/repository/user.py
@@ -82,3 +82,15 @@ async def count_users_with_name(session: AsyncSession, name: str) -> int:
     stmt = select(func.count()).select_from(User).where(User.name == name)
     result = await session.execute(stmt)
     return result.scalar_one()
+
+
+async def increment_token_version(session: AsyncSession, user_id: int) -> int:
+    stmt = (
+        update(User)
+        .where(User.user_id == user_id)
+        .values(token_version=User.token_version + 1)
+        .returning(User.token_version)
+    )
+    result = await session.execute(stmt)
+    await session.commit()
+    return result.scalar_one()

--- a/backend/src/schema/jwt.py
+++ b/backend/src/schema/jwt.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 class TokenPayload(BaseModel):
     sub: str
     username: str
+    version: int = 0
 
 
 class Token(TokenPayload):

--- a/backend/tests/unit/test_security.py
+++ b/backend/tests/unit/test_security.py
@@ -1,6 +1,6 @@
 import hashlib
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import jwt as pyjwt
 import pytest
@@ -264,14 +264,19 @@ class TestVerifyToken:
 
 
 class TestGetJwtUser:
-    def test_valid_token_returns_user(self):
+    @pytest.mark.asyncio
+    async def test_valid_token_returns_user(self):
         payload = TokenPayload(sub="1", username="testuser")
         token = create_access_token(payload)
 
         request = MagicMock(spec=Request)
         request.cookies = {"access_token": token}
 
-        user = get_jwt_user(request)
+        mock_session = MagicMock(spec=AsyncSession)
+        mock_user = MagicMock(token_version=0)
+
+        with patch("core.security.get_user", return_value=mock_user):
+            user = await get_jwt_user(request, mock_session)
 
         from schema.user import UserMinimal
 
@@ -279,27 +284,50 @@ class TestGetJwtUser:
         assert user.user_id == 1
         assert user.name == "testuser"
 
-    def test_missing_token_raises_403(self):
+    @pytest.mark.asyncio
+    async def test_token_version_mismatch_raises_403(self):
+        payload = TokenPayload(sub="1", username="testuser", version=0)
+        token = create_access_token(payload)
+
+        request = MagicMock(spec=Request)
+        request.cookies = {"access_token": token}
+
+        mock_session = MagicMock(spec=AsyncSession)
+        mock_user = MagicMock(token_version=1)
+
+        with patch("core.security.get_user", return_value=mock_user):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_jwt_user(request, mock_session)
+        assert exc_info.value.status_code == 403
+        assert "Token invalidated" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_missing_token_raises_403(self):
         request = MagicMock(spec=Request)
         request.cookies = {}
 
+        mock_session = MagicMock(spec=AsyncSession)
+
         with pytest.raises(HTTPException) as exc_info:
-            get_jwt_user(request)
+            await get_jwt_user(request, mock_session)
         assert exc_info.value.status_code == 403
 
-    def test_refresh_token_as_access_raises_403(self):
+    @pytest.mark.asyncio
+    async def test_refresh_token_as_access_raises_403(self):
         payload = TokenPayload(sub="1", username="testuser")
         token = create_refresh_token(payload)
 
         request = MagicMock(spec=Request)
         request.cookies = {"access_token": token}
 
+        mock_session = MagicMock(spec=AsyncSession)
+
         with pytest.raises(HTTPException) as exc_info:
-            get_jwt_user(request)
+            await get_jwt_user(request, mock_session)
         assert exc_info.value.status_code == 403
 
-    def test_invalid_sub_raises_403(self):
-        # Create token with non-numeric sub
+    @pytest.mark.asyncio
+    async def test_invalid_sub_raises_403(self):
         data = {
             "sub": "not_a_number",
             "username": "testuser",
@@ -313,8 +341,10 @@ class TestGetJwtUser:
         request = MagicMock(spec=Request)
         request.cookies = {"access_token": token}
 
+        mock_session = MagicMock(spec=AsyncSession)
+
         with pytest.raises(HTTPException) as exc_info:
-            get_jwt_user(request)
+            await get_jwt_user(request, mock_session)
         assert exc_info.value.status_code == 403
 
 

--- a/backend/tests/unit/test_security.py
+++ b/backend/tests/unit/test_security.py
@@ -295,9 +295,11 @@ class TestGetJwtUser:
         mock_session = MagicMock(spec=AsyncSession)
         mock_user = MagicMock(token_version=1)
 
-        with patch("core.security.get_user", return_value=mock_user):
-            with pytest.raises(HTTPException) as exc_info:
-                await get_jwt_user(request, mock_session)
+        with (
+            patch("core.security.get_user", return_value=mock_user),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await get_jwt_user(request, mock_session)
         assert exc_info.value.status_code == 403
         assert "Token invalidated" in exc_info.value.detail
 


### PR DESCRIPTION
тк. токен оставался валидным после после logout'a. решил добавить версию для токена в users. как это работает:
1) get_jwt_user при каждом запросе  проверяет рayload.version == user.token_version в БД, если не совпадает, то вылетает ошибка неверного токена
2) при logout  вызывает  token_versionверсия и версия в БД увеличивается, все старые токены этого пользователя становятся невалидными
3) При смене пароля (в login, если new_hash) - тоже инкрементим версию, чтобы старые токены с устаревшим паролем перестали работать