### PR TITLE
User based rate limiting

### DIFF
--- a/backend/src/core/rate_limiter.py
+++ b/backend/src/core/rate_limiter.py
@@ -1,13 +1,34 @@
+import jwt
 from fastapi import Request, Response
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_ipaddr
 
 from core.config import settings
 
-# FIXME: also use user_id as key_func param?
+
+def _rate_limit_key(request: Request) -> str:
+    token_str = request.cookies.get("access_token")
+    if token_str:
+        try:
+            payload = jwt.decode(
+                token_str,
+                settings.JWT_SECRET.get_secret_value(),
+                algorithms=["HS256"],
+            )
+            return f"user:{payload['sub']}"
+        except jwt.PyJWTError:
+            pass
+
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return f"ip:{forwarded.split(',')[0].strip()}"
+    if request.client and request.client.host:
+        return f"ip:{request.client.host}"
+    return "ip:unknown"
+
+
 limiter = Limiter(
-    key_func=get_ipaddr,
+    key_func=_rate_limit_key,
     enabled=not settings.DEV_MODE,
     # Global rate limit: 100/minute for all /api/ routes
     default_limits=[settings.GLOBAL_RATE_LIMIT],

--- a/backend/src/service/records/validation/rules/abundance.py
+++ b/backend/src/service/records/validation/rules/abundance.py
@@ -1,6 +1,6 @@
 from schema.records import RecordData
 
-from ..constants import LIFE_STAGES, QUANTITY_MAX, QUANTITY_TYPES, SEX_VALUES
+from ..constants import QUANTITY_MAX, QUANTITY_TYPES
 from ..helpers import contains_forbidden_chars
 from ..rules.base import RuleCategory, RuleContext, in_set, rule
 
@@ -24,33 +24,8 @@ def rule_each_count_min(data: RecordData, ctx: RuleContext) -> str | None:
     if data.specimens is None:
         return None
     for s in data.specimens:
-        if s.count is not None and s.count < 0.001:
+        if s.count is not None and 0 < s.count < 0.001:
             return "Слишком мало особей"
-    return None
-
-
-@rule(RuleCategory.ABUNDANCE, ["specimens"], "invalid_sex")
-def rule_specimens_valid_sex(data: RecordData, ctx: RuleContext) -> str | None:
-    if data.specimens is None:
-        return None
-    for s in data.specimens:
-        if s.sex not in SEX_VALUES:
-            return "Некорректное значение пола. Допустимые значения: " + ", ".join(
-                sorted(SEX_VALUES)
-            )
-    return None
-
-
-@rule(RuleCategory.ABUNDANCE, ["specimens"], "invalid_lifestage")
-def rule_specimens_valid_lifestage(data: RecordData, ctx: RuleContext) -> str | None:
-    if data.specimens is None:
-        return None
-    for s in data.specimens:
-        if s.life_stage not in LIFE_STAGES:
-            return (
-                "Некорректное значение стадии развития. Допустимые значения: "
-                + ", ".join(sorted(LIFE_STAGES))
-            )
     return None
 
 

--- a/backend/src/service/records/validation/rules/event.py
+++ b/backend/src/service/records/validation/rules/event.py
@@ -92,7 +92,6 @@ def rule_forbidden_chars_event(data: RecordData, ctx: RuleContext) -> str | None
         "sampling_protocol",
         "sampling_effort",
         "sample_size_unit",
-        "event_remarks",
         "recorded_by",
     ],
     "cyrillic",
@@ -104,7 +103,6 @@ def rule_cyrillic_event(data: RecordData, ctx: RuleContext) -> str | None:
         data.sampling_protocol,
         data.sampling_effort,
         data.sample_size_unit,
-        data.event_remarks,
         data.recorded_by,
     ):
         return "Кириллица в блоке Сбор материала для публикации не на русском языке"

--- a/backend/src/service/records/validation/rules/event.py
+++ b/backend/src/service/records/validation/rules/event.py
@@ -92,6 +92,7 @@ def rule_forbidden_chars_event(data: RecordData, ctx: RuleContext) -> str | None
         "sampling_protocol",
         "sampling_effort",
         "sample_size_unit",
+        "event_remarks",
         "recorded_by",
     ],
     "cyrillic",
@@ -103,7 +104,16 @@ def rule_cyrillic_event(data: RecordData, ctx: RuleContext) -> str | None:
         data.sampling_protocol,
         data.sampling_effort,
         data.sample_size_unit,
+        data.event_remarks,
         data.recorded_by,
     ):
         return "Кириллица в блоке Сбор материала для публикации не на русском языке"
+    return None
+
+
+@rule(RuleCategory.EVENT, ["sample_size_value"], "out_of_range")
+def rule_sample_size_positive(data: RecordData, ctx: RuleContext) -> str | None:
+    v = data.sample_size_value
+    if v is not None and v <= 0:
+        return "Объём выборки должен быть положительным числом"
     return None

--- a/backend/src/service/records/validation/rules/location.py
+++ b/backend/src/service/records/validation/rules/location.py
@@ -52,6 +52,8 @@ def rule_country_min_length(data: RecordData, ctx: RuleContext) -> str | None:
     if len(v.strip()) < 4:
         return "Страна указана некорректно"
     return None
+
+
 rule(
     RuleCategory.LOCATION,
     ["region"],

--- a/backend/src/service/records/validation/rules/location.py
+++ b/backend/src/service/records/validation/rules/location.py
@@ -24,7 +24,7 @@ def rule_forbidden_chars_location(data: RecordData, ctx: RuleContext) -> str | N
 
 @rule(
     RuleCategory.LOCATION,
-    ["country", "region", "district", "locality", "location_remarks"],
+    ["country", "region", "district", "locality"],
     "cyrillic",
 )
 def rule_cyrillic_location(data: RecordData, ctx: RuleContext) -> str | None:
@@ -34,7 +34,6 @@ def rule_cyrillic_location(data: RecordData, ctx: RuleContext) -> str | None:
         data.region,
         data.district,
         data.locality,
-        data.location_remarks,
     ):
         return (
             "Кириллица в блоке Административное расположение "

--- a/backend/src/service/records/validation/rules/location.py
+++ b/backend/src/service/records/validation/rules/location.py
@@ -1,5 +1,6 @@
 from schema.records import RecordData
 
+from ..constants import SHORT_COUNTRY_ALLOWLIST
 from ..helpers import contains_forbidden_chars, has_cyrillic_in_foreign_text
 from ..rules.base import RuleCategory, RuleContext, min_length, rule
 
@@ -23,7 +24,7 @@ def rule_forbidden_chars_location(data: RecordData, ctx: RuleContext) -> str | N
 
 @rule(
     RuleCategory.LOCATION,
-    ["country", "region", "district", "locality"],
+    ["country", "region", "district", "locality", "location_remarks"],
     "cyrillic",
 )
 def rule_cyrillic_location(data: RecordData, ctx: RuleContext) -> str | None:
@@ -33,6 +34,7 @@ def rule_cyrillic_location(data: RecordData, ctx: RuleContext) -> str | None:
         data.region,
         data.district,
         data.locality,
+        data.location_remarks,
     ):
         return (
             "Кириллица в блоке Административное расположение "
@@ -41,12 +43,16 @@ def rule_cyrillic_location(data: RecordData, ctx: RuleContext) -> str | None:
     return None
 
 
-rule(
-    RuleCategory.LOCATION,
-    ["country"],
-    "too_short",
-    min_length("country", 4, "Страна указана некорректно"),
-)
+@rule(RuleCategory.LOCATION, ["country"], "too_short")
+def rule_country_min_length(data: RecordData, ctx: RuleContext) -> str | None:
+    v = data.country
+    if v is None:
+        return None
+    if v.strip() in SHORT_COUNTRY_ALLOWLIST:
+        return None
+    if len(v.strip()) < 4:
+        return "Страна указана некорректно"
+    return None
 rule(
     RuleCategory.LOCATION,
     ["region"],

--- a/backend/src/service/records/validation/rules/taxonomy.py
+++ b/backend/src/service/records/validation/rules/taxonomy.py
@@ -101,10 +101,7 @@ def rule_forbidden_chars_taxon(data: RecordData, ctx: RuleContext) -> str | None
 
 @rule(
     RuleCategory.TAXONOMY,
-    [
-        "family", "genus", "species", "accepted_name",
-        "taxon_remarks", "identification_remarks",
-    ],
+    ["family", "genus", "species", "accepted_name", "identification_remarks"],
     "cyrillic",
 )
 def rule_cyrillic_taxon(data: RecordData, ctx: RuleContext) -> str | None:
@@ -114,7 +111,6 @@ def rule_cyrillic_taxon(data: RecordData, ctx: RuleContext) -> str | None:
         data.genus,
         data.species,
         data.accepted_name,
-        data.taxon_remarks,
         data.identification_remarks,
     ):
         return "Кириллица в блоке Таксономия для публикации не на русском языке"

--- a/backend/src/service/records/validation/rules/taxonomy.py
+++ b/backend/src/service/records/validation/rules/taxonomy.py
@@ -101,7 +101,10 @@ def rule_forbidden_chars_taxon(data: RecordData, ctx: RuleContext) -> str | None
 
 @rule(
     RuleCategory.TAXONOMY,
-    ["family", "genus", "species", "accepted_name", "identification_remarks"],
+    [
+        "family", "genus", "species", "accepted_name",
+        "taxon_remarks", "identification_remarks",
+    ],
     "cyrillic",
 )
 def rule_cyrillic_taxon(data: RecordData, ctx: RuleContext) -> str | None:
@@ -111,6 +114,7 @@ def rule_cyrillic_taxon(data: RecordData, ctx: RuleContext) -> str | None:
         data.genus,
         data.species,
         data.accepted_name,
+        data.taxon_remarks,
         data.identification_remarks,
     ):
         return "Кириллица в блоке Таксономия для публикации не на русском языке"


### PR DESCRIPTION
Проблема: Каждый запрос с нового ip получал новый счётчик

Решение: 
1. Замена ip-ключа на  _rate_limit_key:
2. Если в запросе есть уже существующий access_token - ключом становится user:<user_id> (не зависит от ip)
3. Если у запроса нет access_token - мы не можем определить user_id. Тогда лимит считается по IP, как было до
4. f"user:{payload['sub']}" необходимо для исключения коллизий 